### PR TITLE
Fix airport update when no routes

### DIFF
--- a/server.py
+++ b/server.py
@@ -155,8 +155,12 @@ def update_airports():
         })
         route_count += 1
 
-    # Keep only airports that actually have outgoing routes
+    # Keep only airports that actually have outgoing routes. If no routes have
+    # been collected yet, preserve all airports so that update_flights can
+    # match future flights to the nearest airport.
     airports_with_routes = [a for a in airports.values() if a["routes"]]
+    if not airports_with_routes:
+        airports_with_routes = list(airports.values())
 
     AIRPORTS_PATH.write_text(
         json.dumps(airports_with_routes, indent=2)


### PR DESCRIPTION
## Summary
- keep all airports when there are no routes
- test airport update with empty route database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d4cfe150832aadcc2171d433e152