### PR TITLE
Add plane toggle and cleanup routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Use `/update-flights` to gather active flights from the OpenSky API. Flights are
 ]
 ```
 
-Statistics about the collection are written to `$DATA_DIR/routes_stats.json` and can be retrieved via `/routes-stats`.
+Statistics about the collection are written to `$DATA_DIR/routes_stats.json`.
 
 ```bash
 curl -X POST http://localhost:8000/update-flights
@@ -107,10 +107,10 @@ The current dataset can be downloaded with:
 curl http://localhost:8000/routes-db
 ```
 
-For a high level summary of the collected data you can query `/routes-info`:
+For a high level summary of the collected data you can query `/info`:
 
 ```bash
-curl http://localhost:8000/routes-info
+curl http://localhost:8000/info
 ```
 
 The live positions being tracked can also be retrieved via `/active-flights`:

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,7 @@
       <option value="">All</option>
     </select>
     <button id="reset-country">Clear Country</button>
+    <label><input type="checkbox" id="plane-toggle"> Show Planes</label>
   </div>
   <div id="path-row">
     <span id="path"></span>

--- a/public/main.js
+++ b/public/main.js
@@ -11,6 +11,7 @@ const resetBtn = document.getElementById('reset');
 const resetAirlineBtn = document.getElementById('reset-airline');
 const countrySelect = document.getElementById('country-filter');
 const resetCountryBtn = document.getElementById('reset-country');
+const planeToggle = document.getElementById('plane-toggle');
 const selectedRoutes = [];
 const routesPane = map.createPane('routes');
 routesPane.style.zIndex = 200;
@@ -149,6 +150,14 @@ resetCountryBtn.addEventListener('click', () => {
   countrySelect.value = '';
   applyFilter();
 });
+planeToggle.addEventListener('change', () => {
+  if (planeToggle.checked) {
+    loadActiveFlights();
+  } else {
+    activeFlightMarkers.forEach(m => map.removeLayer(m));
+    activeFlightMarkers.length = 0;
+  }
+});
 resetBtn.addEventListener('click', () => {
   markers.forEach(m => {
     m.marker.routesLines.forEach(l => map.removeLayer(l));
@@ -239,5 +248,7 @@ fetch('airports.json')
       });
 
     applyFilter();
-    loadActiveFlights();
+    if (planeToggle.checked) {
+      loadActiveFlights();
+    }
   });

--- a/tests/test_flights.py
+++ b/tests/test_flights.py
@@ -63,12 +63,11 @@ def test_update_flights(tmp_path, monkeypatch):
     assert stats["routes"] == 1
     assert stats["active_planes"] == 1
 
-    info = TestClient(server.app).get("/routes-info").json()
+    info = TestClient(server.app).get("/info").json()
     assert info["routes"] == 1
     assert info["active_planes"] == 1
 
     assert TestClient(server.app).get("/routes-db").status_code == 200
-    assert TestClient(server.app).get("/routes-stats").json()["routes"] == 1
 
 
 def test_update_flights_missing_destination(tmp_path, monkeypatch):
@@ -125,7 +124,7 @@ def test_update_flights_missing_destination(tmp_path, monkeypatch):
     assert stats["routes"] == 1
     assert stats["active_planes"] == 0
 
-    info = TestClient(server.app).get("/routes-info").json()
+    info = TestClient(server.app).get("/info").json()
     assert info["routes"] == 1
     assert info["active_planes"] == 0
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -91,7 +91,7 @@ def test_update_airports(tmp_path, monkeypatch):
     assert stats["airports_active"] == 1
     assert stats["airports_total"] == 2
 
-    info = TestClient(server.app).get("/routes-info").json()
+    info = TestClient(server.app).get("/info").json()
     assert info["active_airports"] == 1
 
 
@@ -142,6 +142,77 @@ def test_update_airports_no_routes(tmp_path, monkeypatch):
     stats = json.loads((data_dir / "routes_stats.json").read_text())
     assert stats["airports_active"] == 2
     assert stats["airports_total"] == 2
+
+
+def test_update_airports_self_clean(tmp_path, monkeypatch):
+    """Routes with identical start and end should be removed."""
+    airports_csv = (
+        "id,ident,type,name,latitude_deg,longitude_deg,elevation_ft,continent,iso_country,iso_region,municipality,scheduled_service,icao_code,iata_code,gps_code,local_code,home_link,wikipedia_link,keywords\n"
+        "1,AAA,airport,AirportA,10,20,,EU,AA,AA-1,CityA,yes,,AAA,AAA,,,\n"
+        "2,BBB,airport,AirportB,30,40,,EU,BB,BB-1,CityB,yes,,BBB,BBB,,,"
+    )
+    countries_csv = (
+        "id,code,name,continent,wikipedia_link,keywords\n"
+        "1,AA,Country AA,EU,,\n"
+        "2,BB,Country BB,EU,,"
+    )
+    airlines_dat = "1,Test Airline,\\N,AL,ALN,CALL,Country,Y\n"
+
+    def fake_get(url):
+        if "airports.csv" in url:
+            return fake_response(airports_csv)
+        if "countries.csv" in url:
+            return fake_response(countries_csv)
+        if "airlines.dat" in url:
+            return fake_response(airlines_dat)
+        raise AssertionError(url)
+
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (tmp_path / "public").mkdir()
+    monkeypatch.setattr(server.requests, "get", fake_get)
+    monkeypatch.setattr(server, "DATA_DIR", data_dir)
+    monkeypatch.setattr(server, "AIRPORTS_PATH", data_dir / "airports.json")
+    monkeypatch.setattr(server, "ROUTES_DB_PATH", data_dir / "routes_dynamic.json")
+    monkeypatch.setattr(server, "STATS_PATH", data_dir / "routes_stats.json")
+
+    routes = [
+        {
+            "airline": "AL",
+            "flight_number": "1",
+            "icao24": "abc",
+            "source": "AAA",
+            "destination": "AAA",
+            "first_seen": "t",
+            "last_seen": "t",
+            "status": "Active",
+        },
+        {
+            "airline": "AL",
+            "flight_number": "2",
+            "icao24": "xyz",
+            "source": "AAA",
+            "destination": "BBB",
+            "first_seen": "t",
+            "last_seen": "t",
+            "status": "Active",
+        },
+    ]
+    (data_dir / "routes_dynamic.json").write_text(json.dumps(routes))
+
+    client = TestClient(server.app)
+    resp = client.post("/update-airports")
+    assert resp.status_code == 200
+
+    data = json.loads((data_dir / "airports.json").read_text())
+    assert len(data) == 1
+    assert len(data[0]["routes"]) == 1
+    assert data[0]["routes"][0]["to_name"] == "AirportB"
+
+    routes_db = json.loads((data_dir / "routes_dynamic.json").read_text())
+    assert len(routes_db) == 1
+    assert routes_db[0]["destination"] == "BBB"
 
 
 def test_get_airports_missing(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow toggling plane markers in UI
- clean routes with same start and end when updating airports
- drop `/routes-stats` endpoint and rename `/routes-info` to `/info`
- update docs and tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e4c5cadc832abfb6ebd73e796ca0