### PR TITLE
Add airline filter for active planes

### DIFF
--- a/public/airports.json
+++ b/public/airports.json
@@ -12,14 +12,16 @@
         "to": [48.8566, 2.3522],
         "from_name": "London Heathrow",
         "to_name": "Paris Charles de Gaulle",
-        "airline": "British Airways"
+        "airline": "British Airways",
+        "airline_code": "BA"
       },
       {
         "from": [51.4706, -0.4619],
         "to": [52.5200, 13.4050],
         "from_name": "London Heathrow",
         "to_name": "Berlin",
-        "airline": "British Airways"
+        "airline": "British Airways",
+        "airline_code": "BA"
       }
     ]
   },
@@ -36,7 +38,8 @@
         "to": [41.9028, 12.4964],
         "from_name": "Paris Charles de Gaulle",
         "to_name": "Rome",
-        "airline": "Air France"
+        "airline": "Air France",
+        "airline_code": "AF"
       }
     ]
   }

--- a/public/main.js
+++ b/public/main.js
@@ -29,6 +29,8 @@ const colorPalette = [
   '#000075', '#808080'
 ];
 
+const airlineNameToCode = {};
+
 const planeIcon = L.icon({
   iconUrl: 'plane.svg',
   iconSize: [8, 8],
@@ -122,8 +124,9 @@ function loadActiveFlights() {
       activeFlightMarkers.forEach(m => activeFlightsLayer.removeLayer(m));
       activeFlightMarkers.length = 0;
       const airlineFilter = filterSelect.value;
+      const filterCode = airlineNameToCode[airlineFilter] || airlineFilter;
       Object.values(data || {}).forEach(f => {
-        if (airlineFilter && f.airline !== airlineFilter) return;
+        if (airlineFilter && f.airline !== filterCode) return;
         if (!Array.isArray(f.last_coord)) return;
         const [lat, lon] = f.last_coord;
         if (lat == null || lon == null) return;
@@ -199,7 +202,12 @@ fetch('airports.json')
     const countriesMap = new Map();
 
     airportsData.forEach(a => {
-      a.routes.forEach(r => airlinesSet.add(r.airline));
+      a.routes.forEach(r => {
+        airlinesSet.add(r.airline);
+        if (r.airline && r.airline_code) {
+          airlineNameToCode[r.airline] = r.airline_code;
+        }
+      });
       countriesMap.set(a.country_code, a.country);
 
       const marker = L.circleMarker([a.lat, a.lon], {

--- a/server.py
+++ b/server.py
@@ -197,6 +197,7 @@ def update_airports():
             "from_name": src["name"],
             "to_name": dest["name"],
             "airline": airline_name,
+            "airline_code": prefix,
             "flight_number": number
         })
         route_count += 1


### PR DESCRIPTION
## Summary
- include `airline_code` in airport route data
- track airline name to code mapping on the client
- filter active flights using code derived from selected airline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851f2725d10832ab0045007ca0295ae