### PR TITLE
Remove inactive endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ Two airport files are produced when running `update-airports`:
 * `airports.json` – only airports that have routes; used by the front-end.
 * `airports_full.json` – the complete list of airports used internally for matching flights to the nearest airport.
 
+### `/data` contents
+
+When `DATA_DIR` is set, the API writes its working datasets to that directory:
+
+* `airports.json` – filtered airports for the UI.
+* `airports_full.json` – full airport list.
+* `routes_dynamic.json` – recovered routes. Example:
+
+  ```json
+  [
+    {"airline": "BT", "flight_number": "123", "source": "EVRA", "destination": "EGLL"}
+  ]
+  ```
+* `active_flights.json` – currently tracked flights, e.g. `{"abc": {"callsign": "AL123", "last_coord": [10, 20]}}`.
+* `routes_stats.json` – statistics about collected routes.
+
 ### Updating data
 
 Run the `/update-airports` endpoint to download the latest airports from OurAirports and merge them with your collected flight database (`routes_dynamic.json`):
@@ -110,23 +126,12 @@ Statistics about the collection are written to `$DATA_DIR/routes_stats.json`.
 curl -X POST http://localhost:8000/update-flights
 ```
 
-The current dataset can be downloaded with:
-
-```bash
-curl http://localhost:8000/routes-db
-```
-
 For a high level summary of the collected data you can query `/info`:
 
 ```bash
 curl http://localhost:8000/info
 ```
 
-The live positions being tracked can also be retrieved via `/active-flights`:
-
-```bash
-curl http://localhost:8000/active-flights
-```
 
 ## Deployment on Railway
 

--- a/server.py
+++ b/server.py
@@ -365,18 +365,7 @@ def update_flights():
     return {"routes": len(routes), "active": len(active), "last_run": now}
 
 
-@app.get("/active-flights")
-def get_active_flights():
-    """Return the currently tracked active flights."""
-    if ACTIVE_FLIGHTS_PATH.exists():
-        return FileResponse(ACTIVE_FLIGHTS_PATH)
-    return {}
 
-
-@app.get("/routes-db")
-def get_routes_db():
-    """Return the dynamically built routes database."""
-    return FileResponse(ROUTES_DB_PATH)
 
 
 @app.get("/info")

--- a/tests/test_flights.py
+++ b/tests/test_flights.py
@@ -70,7 +70,7 @@ def test_update_flights(tmp_path, monkeypatch):
     assert info["routes"] == 1
     assert info["active_planes"] == 1
 
-    assert TestClient(server.app).get("/routes-db").status_code == 200
+
 
 
 def test_update_flights_missing_destination(tmp_path, monkeypatch):
@@ -135,18 +135,4 @@ def test_update_flights_missing_destination(tmp_path, monkeypatch):
     assert info["active_planes"] == 0
 
 
-def test_get_active_flights(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    data_dir = tmp_path / "data"
-    data_dir.mkdir()
-    (tmp_path / "public").mkdir()
-    monkeypatch.setattr(server, "DATA_DIR", data_dir)
-    monkeypatch.setattr(server, "ACTIVE_FLIGHTS_PATH", data_dir / "active_flights.json")
-    active = {"abc": {"callsign": "AL123", "last_coord": [10, 20]}}
-    (data_dir / "active_flights.json").write_text(json.dumps(active))
-
-    client = TestClient(server.app)
-    resp = client.get("/active-flights")
-    assert resp.status_code == 200
-    assert resp.json() == active
 


### PR DESCRIPTION
## Summary
- drop `/routes-db` and `/active-flights` routes
- revise tests to match
- document `/data` directory contents and remove outdated endpoint references

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b05939b4832aa8a29e13d9682749