### PR TITLE
Ensure routes added for both origin and destination

### DIFF
--- a/server.py
+++ b/server.py
@@ -191,14 +191,24 @@ def update_airports():
         prefix = rt.get("airline", "")
         number = rt.get("flight_number", "")
         airline_name = airline_names.get(prefix, prefix)
+        route_details = {
+            "airline": airline_name,
+            "airline_code": prefix,
+            "flight_number": number,
+        }
         src["routes"].append({
+            **route_details,
             "from": [src["lat"], src["lon"]],
             "to": [dest["lat"], dest["lon"]],
             "from_name": src["name"],
             "to_name": dest["name"],
-            "airline": airline_name,
-            "airline_code": prefix,
-            "flight_number": number
+        })
+        dest["routes"].append({
+            **route_details,
+            "from": [dest["lat"], dest["lon"]],
+            "to": [src["lat"], src["lon"]],
+            "from_name": dest["name"],
+            "to_name": src["name"],
         })
         route_count += 1
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -81,22 +81,27 @@ def test_update_airports(tmp_path, monkeypatch):
     assert resp.status_code == 200
 
     data = json.loads((data_dir / "airports.json").read_text())
-    assert len(data) == 1
-    assert len(data[0]["routes"]) == 1
-    assert data[0]["routes"][0]["airline"] == "Test Airline"
-    assert data[0]["routes"][0]["flight_number"] == "123"
-    assert data[0]["country_code"] == "AA"
-    assert data[0]["country"] == "Country AA"
+    assert len(data) == 2
+    airports = {a["code"]: a for a in data}
+    a_aaa = airports["AAA"]
+    a_bbb = airports["BBB"]
+    assert len(a_aaa["routes"]) == 1
+    assert len(a_bbb["routes"]) == 1
+    assert a_aaa["routes"][0]["airline"] == "Test Airline"
+    assert a_aaa["routes"][0]["flight_number"] == "123"
+    assert a_bbb["routes"][0]["to_name"] == "AirportA"
+    assert a_aaa["country_code"] == "AA"
+    assert a_aaa["country"] == "Country AA"
 
     stats = json.loads((data_dir / "routes_stats.json").read_text())
-    assert stats["airports_active"] == 1
+    assert stats["airports_active"] == 2
     assert stats["airports_total"] == 2
 
     full = json.loads((data_dir / "airports_full.json").read_text())
     assert len(full) == 2
 
     info = TestClient(server.app).get("/info").json()
-    assert info["active_airports"] == 1
+    assert info["active_airports"] == 2
 
 
 def test_update_airports_no_routes(tmp_path, monkeypatch):
@@ -215,9 +220,11 @@ def test_update_airports_self_clean(tmp_path, monkeypatch):
     assert resp.status_code == 200
 
     data = json.loads((data_dir / "airports.json").read_text())
-    assert len(data) == 1
-    assert len(data[0]["routes"]) == 1
-    assert data[0]["routes"][0]["to_name"] == "AirportB"
+    assert len(data) == 2
+    airports = {a["code"]: a for a in data}
+    assert len(airports["AAA"]["routes"]) == 1
+    assert len(airports["BBB"]["routes"]) == 1
+    assert airports["AAA"]["routes"][0]["to_name"] == "AirportB"
 
     routes_db = json.loads((data_dir / "routes_dynamic.json").read_text())
     assert len(routes_db) == 1


### PR DESCRIPTION
## Summary
- add routes to both origin and destination airports when updating airports
- update related tests for the new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f8904400832a82291ed61757774d