### PR TITLE
Add admin page for managing data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ The live flights currently being tracked can be retrieved via `/active-planes`:
 curl http://localhost:8000/active-planes
 ```
 
+## Admin Interface
+
+Browse to `/admin.html` for a simple administrator page listing the files in
+the `$DATA_DIR` directory. Each entry shows the last modified time, file size
+and record count with options to download, upload a replacement or delete the
+file.
+
 
 ## Deployment on Railway
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 6px 8px; }
+    input[type=file] { width: 200px; }
+  </style>
+</head>
+<body>
+  <h1>Data Files</h1>
+  <table id="file-table">
+    <thead>
+      <tr>
+        <th>File</th>
+        <th>Last Modified</th>
+        <th>Size</th>
+        <th>Records</th>
+        <th>Download</th>
+        <th>Upload New</th>
+        <th>Delete</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script>
+    async function loadFiles() {
+      const resp = await fetch('admin/files');
+      const data = await resp.json();
+      const tbody = document.querySelector('#file-table tbody');
+      tbody.innerHTML = '';
+        (data.files || []).forEach(f => {
+          const tr = document.createElement('tr');
+          const downloadLink = document.createElement('a');
+          downloadLink.href = `admin/download/${encodeURIComponent(f.name)}`;
+          downloadLink.textContent = 'Download';
+          const fileInput = document.createElement('input');
+          fileInput.type = 'file';
+          const uploadBtn = document.createElement('button');
+          uploadBtn.textContent = 'Upload';
+          uploadBtn.onclick = async () => {
+            if (!fileInput.files.length) return;
+            const form = new FormData();
+            form.append('file', fileInput.files[0]);
+            await fetch(`admin/upload/${encodeURIComponent(f.name)}`, { method: 'POST', body: form });
+            loadFiles();
+          };
+          const deleteBtn = document.createElement('button');
+          deleteBtn.textContent = 'Delete';
+          deleteBtn.onclick = async () => {
+            await fetch(`admin/delete/${encodeURIComponent(f.name)}`, { method: 'DELETE' });
+            loadFiles();
+          };
+          tr.innerHTML = `<td>${f.name}</td><td>${f.modified}</td><td>${f.size}</td><td>${f.records}</td>`;
+          const tdDownload = document.createElement('td');
+          tdDownload.appendChild(downloadLink);
+          const tdUpload = document.createElement('td');
+          tdUpload.appendChild(fileInput);
+          tdUpload.appendChild(uploadBtn);
+          const tdDelete = document.createElement('td');
+          tdDelete.appendChild(deleteBtn);
+          tr.appendChild(tdDownload);
+          tr.appendChild(tdUpload);
+          tr.appendChild(tdDelete);
+          tbody.appendChild(tr);
+        });
+    }
+    loadFiles();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pytest
 httpx
 scipy
+python-multipart

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path as SysPath
+sys.path.insert(0, str(SysPath(__file__).resolve().parents[1]))
+import server
+
+
+def setup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (tmp_path / "public").mkdir()
+    monkeypatch.setattr(server, "DATA_DIR", data_dir)
+    return data_dir, TestClient(server.app)
+
+
+def test_admin_file_ops(tmp_path, monkeypatch):
+    data_dir, client = setup(tmp_path, monkeypatch)
+    (data_dir / "test.txt").write_text("hello")
+
+    resp = client.get("/admin/files")
+    assert resp.status_code == 200
+    entries = resp.json()["files"]
+    names = [f["name"] for f in entries]
+    assert "test.txt" in names
+    info = next(f for f in entries if f["name"] == "test.txt")
+    assert "size" in info and info["size"] > 0
+    assert "records" in info
+
+    resp = client.get("/admin/download/test.txt")
+    assert resp.status_code == 200
+    assert resp.text == "hello"
+
+    resp = client.post(
+        "/admin/upload/new.txt",
+        files={"file": ("new.txt", b"data")},
+    )
+    assert resp.status_code == 200
+    assert (data_dir / "new.txt").read_text() == "data"
+
+    resp = client.delete("/admin/delete/test.txt")
+    assert resp.status_code == 200
+    assert not (data_dir / "test.txt").exists()
+
+    resp = client.get("/admin/files")
+    assert "test.txt" not in [f["name"] for f in resp.json()["files"]]


### PR DESCRIPTION
## Summary
- create admin API endpoints for listing, downloading and uploading data files
- add `/admin.html` frontend for simple file management
- document admin page usage
- add tests for admin endpoints
- require `python-multipart` for file uploads
- extend admin page with delete option
- show file size and record count in admin listing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68540b8f52f8832a9b57186f3f095f2a