### PR TITLE
Add delete option and metadata to admin UI

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -14,7 +14,15 @@
   <h1>Data Files</h1>
   <table id="file-table">
     <thead>
-      <tr><th>File</th><th>Last Modified</th><th>Download</th><th>Upload New</th></tr>
+      <tr>
+        <th>File</th>
+        <th>Last Modified</th>
+        <th>Size</th>
+        <th>Records</th>
+        <th>Download</th>
+        <th>Upload New</th>
+        <th>Delete</th>
+      </tr>
     </thead>
     <tbody></tbody>
   </table>
@@ -40,14 +48,24 @@
           await fetch(`admin/upload/${encodeURIComponent(f.name)}`, { method: 'POST', body: form });
           loadFiles();
         };
-        tr.innerHTML = `<td>${f.name}</td><td>${f.modified}</td>`;
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = 'Delete';
+        deleteBtn.onclick = async () => {
+          if (!confirm(`Delete ${f.name}?`)) return;
+          await fetch(`admin/delete/${encodeURIComponent(f.name)}`, { method: 'DELETE' });
+          loadFiles();
+        };
+        tr.innerHTML = `<td>${f.name}</td><td>${f.modified}</td><td>${f.size}</td><td>${f.records}</td>`;
         const tdDownload = document.createElement('td');
         tdDownload.appendChild(downloadLink);
         const tdUpload = document.createElement('td');
         tdUpload.appendChild(fileInput);
         tdUpload.appendChild(uploadBtn);
+        const tdDelete = document.createElement('td');
+        tdDelete.appendChild(deleteBtn);
         tr.appendChild(tdDownload);
         tr.appendChild(tdUpload);
+        tr.appendChild(tdDelete);
         tbody.appendChild(tr);
       });
     }

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -35,3 +35,16 @@ def test_admin_file_ops(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert (data_dir / "new.txt").read_text() == "data"
+
+    # New file metadata
+    resp = client.get("/admin/files")
+    assert resp.status_code == 200
+    files = resp.json()["files"]
+    info = next(f for f in files if f["name"] == "new.txt")
+    assert "size" in info and info["size"] == 4
+    assert "records" in info
+
+    # Delete file
+    resp = client.delete("/admin/delete/test.txt")
+    assert resp.status_code == 200
+    assert not (data_dir / "test.txt").exists()


### PR DESCRIPTION
## Summary
- add file size and record counts to `/admin/files`
- add endpoint to delete data files
- update admin UI to show size/records and add a delete button
- extend admin test to cover new features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544e99de98832a9933e93768297f71