### PR TITLE
Remove generated diagram PNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 
 __pycache__/
+diagrams/*.png

--- a/README.md
+++ b/README.md
@@ -149,3 +149,15 @@ to download the file or upload a replacement.
 ## Deployment on Railway
 
 Create a project from this repository and configure a persistent volume mounted at `/data`. Set the `DATA_DIR` environment variable to `/data` so updated airport data persists between deployments.
+
+## Architecture
+
+Architecture diagrams in [C4](https://c4model.com/) notation are provided in the
+`diagrams` directory. To regenerate the images:
+
+```bash
+plantuml diagrams/*.puml
+```
+
+The diagrams cover the system context, container relationships and key
+components of the FastAPI server.

--- a/diagrams/components.puml
+++ b/diagrams/components.puml
@@ -1,0 +1,23 @@
+@startuml
+!include <C4/C4_Component>
+
+Container(api, "FastAPI Server", "Python") {
+  Component(api_routes, "API Endpoints", "FastAPI", "/update-airports, /update-routes, /active-planes, /info, /admin")
+  Component(data_manager, "Data Manager", "Python", "Reads and writes JSON datasets")
+  Component(nearest, "Nearest Airport Lookup", "Python", "KDTree for geolocation")
+  Component(static_files, "Static File Server", "FastAPI", "Serves HTML/JS from /public")
+}
+ContainerDb(data, "Data Directory", "JSON files")
+System_Ext(opensky, "OpenSky Network")
+System_Ext(ourairports, "OurAirports")
+System_Ext(openflights, "OpenFlights")
+
+Rel(api_routes, data_manager, "Reads/Writes")
+Rel(data_manager, data, "JSON files")
+Rel(api_routes, nearest, "Locate airports")
+Rel(api_routes, opensky, "Fetch flights")
+Rel(api_routes, ourairports, "Download airports")
+Rel(api_routes, openflights, "Download airlines")
+Rel_L(api_routes, static_files, "Serves UI")
+
+@enduml

--- a/diagrams/container.puml
+++ b/diagrams/container.puml
@@ -1,0 +1,22 @@
+@startuml
+!include <C4/C4_Container>
+
+Person(user, "User")
+System_Boundary(flightmap, "Flight Map") {
+  Container(spa, "Browser", "JavaScript", "Leaflet map and UI")
+  Container(api, "FastAPI Server", "Python", "Serves data and updates routes")
+  ContainerDb(data, "Data Directory", "JSON files", "Airports, routes, stats")
+}
+System_Ext(opensky, "OpenSky Network")
+System_Ext(ourairports, "OurAirports")
+System_Ext(openflights, "OpenFlights")
+
+Rel(user, spa, "Uses")
+Rel(spa, api, "HTTP")
+Rel(api, opensky, "Fetch flights")
+Rel(api, ourairports, "Download airports")
+Rel(api, openflights, "Download airlines")
+Rel(api, data, "Read/write")
+Rel(api, spa, "Serve static files")
+
+@enduml

--- a/diagrams/context.puml
+++ b/diagrams/context.puml
@@ -1,0 +1,15 @@
+@startuml
+!include <C4/C4_Context>
+
+Person(user, "User", "Interacts with the map via a browser")
+System(flightmap, "Flight Map", "Interactive route map for Europe")
+System_Ext(opensky, "OpenSky Network", "Provides live flight data")
+System_Ext(ourairports, "OurAirports", "Source of airport and country data")
+System_Ext(openflights, "OpenFlights", "Provides airline names")
+
+Rel(user, flightmap, "Uses")
+Rel(flightmap, opensky, "Fetch active flights")
+Rel(flightmap, ourairports, "Download airport data")
+Rel(flightmap, openflights, "Download airline codes")
+
+@enduml


### PR DESCRIPTION
## Summary
- clean up repo by deleting generated PNG diagrams
- ignore PNG files in `diagrams` directory

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866e76cb680832a9cca174b84af7f29