### PR TITLE
Show route additions and removals

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -69,10 +69,12 @@ function updateStatsDisplay() {
   const visiblePlanes = planeToggle.checked ? activeFlightMarkers.size : 0;
   const totalPlanes = infoStats.active_planes || 0;
   const routes = infoStats.routes || 0;
-  const recent = infoStats.recovered_last_hour || 0;
-  statsEl.textContent = `Airports: ${visibleAirports}/${totalAirports} | ` +
+  const added = infoStats.recovered_last_hour || 0;
+  const removed = infoStats.removed_last_hour || 0;
+  statsEl.innerHTML = `Airports: ${visibleAirports}/${totalAirports} | ` +
     `Planes: ${visiblePlanes}/${totalPlanes} | ` +
-    `Routes: ${routes} (last hr: ${recent})`;
+    `Routes: ${routes} (last hr: <span style="color:green">+${added}</span> ` +
+    `<span style="color:red">-${removed}</span>)`;
 }
 
 function applyFilter() {

--- a/server.py
+++ b/server.py
@@ -340,6 +340,7 @@ def update_routes():
 
     # Update status and prune old routes
     cleaned = []
+    pruned = 0
     now_dt = datetime.utcnow()
     for r in routes:
         try:
@@ -347,6 +348,7 @@ def update_routes():
         except Exception:
             last_dt = now_dt
         if now_dt - last_dt > timedelta(days=31):
+            pruned += 1
             continue
         r["status"] = "Active" if now_dt - last_dt <= timedelta(days=21) else "Not Active"
         cleaned.append(r)
@@ -360,6 +362,7 @@ def update_routes():
         "routes": len(routes),
         "last_run": now,
         "active_planes": len(active),
+        "removed_last_run": pruned,
     })
     write_json(STATS_PATH, stats)
     update_airports()
@@ -409,6 +412,7 @@ def get_routes_info():
         "active_planes": stats.get("active_planes", 0),
         "recovered_last_hour": recovered_hour,
         "recovered_last_24h": recovered_day,
+        "removed_last_hour": stats.get("removed_last_run", 0),
     }
 
 

--- a/tests/test_flights.py
+++ b/tests/test_flights.py
@@ -202,5 +202,11 @@ def test_route_expiration(tmp_path, monkeypatch):
     remaining = json.loads((data_dir / "routes_dynamic.json").read_text())
     assert remaining == []
 
+    stats = json.loads((data_dir / "routes_stats.json").read_text())
+    assert stats["removed_last_run"] == 1
+
+    info = TestClient(server.app).get("/info").json()
+    assert info["removed_last_hour"] == 1
+
 
 


### PR DESCRIPTION
## Summary
- track removed routes when pruning old data
- expose removed route count from `/info`
- highlight added and removed routes in stats display
- test that removed routes are reported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8fa1c0f8832aa8ab08d6817a47e1